### PR TITLE
Add missing attribute `scopes` to I18n for doorkeeper/application

### DIFF
--- a/rails/locales/de.yml
+++ b/rails/locales/de.yml
@@ -4,6 +4,7 @@ de:
       doorkeeper/application:
         name: 'Name'
         redirect_uri: 'Redirect URI'
+        scopes: 'Scopes'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/en.yml
+++ b/rails/locales/en.yml
@@ -4,6 +4,7 @@ en:
       doorkeeper/application:
         name: 'Name'
         redirect_uri: 'Redirect URI'
+        scopes: 'Scopes'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/es.yml
+++ b/rails/locales/es.yml
@@ -4,6 +4,7 @@ es:
       doorkeeper/application:
         name: 'Nombre'
         redirect_uri: 'URI de redirección'
+        scopes: ~
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/fi.yml
+++ b/rails/locales/fi.yml
@@ -4,6 +4,7 @@ fi:
       doorkeeper/application:
         name: 'Nimi'
         redirect_uri: 'Uudelleenohjauksen URI'
+        scopes: 'Näkyvyysalueet'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/fr.yml
+++ b/rails/locales/fr.yml
@@ -4,6 +4,7 @@ fr:
       doorkeeper/application:
         name: "Nom"
         redirect_uri: "L'URL de redirection"
+        scopes: "Portées"
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/it.yml
+++ b/rails/locales/it.yml
@@ -4,6 +4,7 @@ it:
       doorkeeper/application:
         name: 'Nome'
         redirect_uri: 'Redirect URI'
+        scopes: ~
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
       doorkeeper/application:
         name: '名前'
         redirect_uri: 'リダイレクトURI'
+        scopes: 'スコープ'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/nb.yml
+++ b/rails/locales/nb.yml
@@ -4,6 +4,7 @@ nb:
       doorkeeper/application:
         name: 'Navn'
         redirect_uri: 'VideresendingsURI'
+        scopes: 'Tagger'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/nl.yml
+++ b/rails/locales/nl.yml
@@ -4,6 +4,7 @@ nl:
       doorkeeper/application:
         name: 'Naam'
         redirect_uri: 'Redirect URI'
+        scopes: 'Scopes'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/pt-BR.yml
+++ b/rails/locales/pt-BR.yml
@@ -4,6 +4,7 @@ pt-BR:
       doorkeeper/application:
         name: 'Nome'
         redirect_uri: 'URI de redirecionamento'
+        scopes: ~
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/zh-CN.yml
+++ b/rails/locales/zh-CN.yml
@@ -4,6 +4,7 @@ zh-CN:
       doorkeeper/application:
         name: '名称'
         redirect_uri: '登录回调地址'
+        scopes: 'Scopes'
     errors:
       models:
         doorkeeper/application:

--- a/rails/locales/zh-TW.yml
+++ b/rails/locales/zh-TW.yml
@@ -4,6 +4,7 @@ zh-TW:
       doorkeeper/application:
         name: '名稱'
         redirect_uri: '轉向網址'
+        scopes: ~
     errors:
       models:
         doorkeeper/application:


### PR DESCRIPTION
For completeness, the `scopes` attribute should be added, so that it won't be overlooked when creating translations.