### PR TITLE
fix japanese locales for destroy action

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -108,7 +108,7 @@ ja:
         create:
           notice: 'アプリケーションが作成されました。'
         destroy:
-          notice: 'アプリケーションが作成されました。'
+          notice: 'アプリケーションが削除されました。'
         update:
           notice: 'アプリケーションが更新されました。'
       authorized_applications:


### PR DESCRIPTION
SSIA.

作成: create
削除: destroy

probably mistake when copying.