### PR TITLE
Fixes spelling mistake

### DIFF
--- a/rails/locales/nl.yml
+++ b/rails/locales/nl.yml
@@ -107,7 +107,7 @@ nl:
         admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
 
         # Access grant errors
-        unsupported_response_type: 'De authorisatie server ondersteund dit response type niet'
+        unsupported_response_type: 'De authorisatie server ondersteunt dit response type niet'
 
         # Access token errors
         invalid_client: 'Client verificatie is mislukt door onbekende klant, geen client authenticatie opgegeven, of een niet-ondersteunde authenticatie methode.'


### PR DESCRIPTION
This pull request fixes a spelling mistake in Dutch.
The third person present tense of the verb "[ondersteunen](https://nl.wiktionary.org/wiki/ondersteunen)" was misspelled. This can be verified at [verbix](https://www.verbix.com/webverbix/go.php?T1=ondersteunen&Submit=Go&D1=24&H1=124).