### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 cache: bundler
 language: ruby
 sudo: false
+arch:
+  - amd64
+  - ppc64le
 
 rvm:
   - 2.6.2


### PR DESCRIPTION
Added support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/doorkeeper-i18n/builds/209081762