### PR TITLE
Add Japanese translation for `forbidden_token.missing_scope` that is added in Doorkeeper v5.5.3

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -121,6 +121,9 @@ ja:
         revoke:
           unauthorized: "このトークンを無効化する権限がありません"
 
+        forbidden_token:
+          missing_scope: "このリソースにアクセスするには次のスコープが必要です。%{oauth_scopes}"
+
     flash:
       applications:
         create:


### PR DESCRIPTION
[Doorkeeper v5.5.3](https://github.com/doorkeeper-gem/doorkeeper/releases/tag/v5.5.3)