### PR TITLE
Fix untranslated English fragment in Japanese locale

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -99,7 +99,7 @@ ja:
         temporarily_unavailable: 認可サーバが一時的に高負荷な状態にあるか、もしくはメンテナンス中であるため、リクエストを処理できません。
         credential_flow_not_configured: Doorkeeper.configure.resource_owner_from_credentials が設定されていないため、リソースオーナーパスワードクレデンシャルフローは失敗しました。
         resource_owner_authenticator_not_configured: Doorkeeper.configure.resource_owner_authenticator が設定されていないため、リソースオーナーの取得に失敗しました。
-        admin_authenticator_not_configured: Doorkeeper.configure.admin_authenticator being unconfigured が設定されていないため、管理者パネルへのアクセスが禁止されています。
+        admin_authenticator_not_configured: Doorkeeper.configure.admin_authenticator が設定されていないため、管理者パネルへのアクセスが禁止されています。
         unsupported_response_type: 認可サーバは指定されたレスポンスタイプをサポートしていません。
         unsupported_response_mode: The authorization server does not support this response mode.
         invalid_client: クライアントが不明か、クライアント認証が含まれていないか、もしくは認証メソッドがサポートされていないため、クライアント認証は失敗しました。


### PR DESCRIPTION
The `admin_authenticator_not_configured` error message in `ja.yml` contains a leftover English fragment "being unconfigured" that was not removed during translation. "being unconfigured" means "設定されていない" in Japanese, so the current text is redundant:

Before:
  Doorkeeper.configure.admin_authenticator being unconfigured が設定されていないため、…

After:
  Doorkeeper.configure.admin_authenticator が設定されていないため、…

This aligns with the pattern used by the other `*_not_configured` messages in the same file ([lines 100–101](https://github.com/doorkeeper-gem/doorkeeper-i18n/blob/99626e6d3b8bd15cf0155e5057dc8054691257a4/rails/locales/ja.yml#L100-L101)).